### PR TITLE
chore: add SES worker env bindings

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,6 +29,10 @@ export interface Env {
   STRIPE_PRO_PRICE_ID: string
   RESEND_API_KEY?: string
   RESEND_WEBHOOK_SECRET?: string
+  SES_AWS_ACCESS_KEY_ID?: string
+  SES_AWS_SECRET_ACCESS_KEY?: string
+  SES_REGION?: string
+  SES_FROM_EMAIL?: string
   PAUSE_NONCRITICAL_EMAIL?: string
   ADMIN_SECRET?: string
   ADMIN_TOKEN?: string

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -19,6 +19,8 @@ id = "731e18288e9e4de091e01e0a5d6d3cc4"
 
 [vars]
 ENVIRONMENT = "production"
+SES_REGION = "us-west-2"
+SES_FROM_EMAIL = "hello@socialproof.dev"
 
 [triggers]
 crons = ["0 * * * *"]  # Run hourly for drip email sequence
@@ -30,3 +32,6 @@ port = 8787
 # Required for transactional email via Resend:
 #   RESEND_API_KEY  - get from resend.com dashboard
 #                    wrangler secret put RESEND_API_KEY
+# Required for transactional email via Amazon SES:
+#   SES_AWS_ACCESS_KEY_ID      wrangler secret put SES_AWS_ACCESS_KEY_ID
+#   SES_AWS_SECRET_ACCESS_KEY  wrangler secret put SES_AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Summary
- add SES env bindings to worker runtime type (`SES_AWS_ACCESS_KEY_ID`, `SES_AWS_SECRET_ACCESS_KEY`, `SES_REGION`, `SES_FROM_EMAIL`)
- set production worker vars in `wrangler.toml` for `SES_REGION=us-west-2` and `SES_FROM_EMAIL=hello@socialproof.dev`
- document required Wrangler secret commands for SES in worker config comments
- SES AWS keys have been added to the production worker via `wrangler secret put`

## Test plan
- [x] Confirm `wrangler secret put SES_AWS_ACCESS_KEY_ID` succeeded for worker `vouch-worker`
- [x] Confirm `wrangler secret put SES_AWS_SECRET_ACCESS_KEY` succeeded for worker `vouch-worker`
- [x] Verify TypeScript env bindings compile context updated in `apps/worker/src/index.ts`
- [ ] Follow-up PR to switch email sending path from Resend to SES SigV4


Made with [Cursor](https://cursor.com)